### PR TITLE
Update protobuf.sh

### DIFF
--- a/protobuf.sh
+++ b/protobuf.sh
@@ -213,7 +213,7 @@ if [ "${MODE}" == "install" ]; then
     make || fail
     make check || fail
     make install || fail
-    ldconfig || fail
+    # ldconfig || fail
     cd ${DOWNLOAD_DIR} || fail
     rm ${PROTOBUF_ARCHIVE} || fail
     echo "Protobuf has been installed to ${INSTALL_DIR}"


### PR DESCRIPTION
Removing ldconfig error that happened on Mac OSx Sierra when running command `./protobuf.sh install ../tensorflow examples/install-project/`

```
ll-project/include/google/protobuf/compiler/js'
./protobuf.sh: line 216: ldconfig: command not found
Command failed - script terminated
```
